### PR TITLE
Enable ormolu saving on all haskell files

### DIFF
--- a/ftplugin/haskell/ormolu-haskell.vim
+++ b/ftplugin/haskell/ormolu-haskell.vim
@@ -70,5 +70,5 @@ endfunction
 
 augroup ormolu-haskell
   autocmd!
-  autocmd BufWritePost *.hs call s:OrmoluSave()
+  autocmd BufWritePost * if &filetype == 'haskell' | call s:OrmoluSave() | endif
 augroup END


### PR DESCRIPTION
Some Haskell files start with a shebang:
```
#!/usr/bin/env stack
```
and vim can detect this line and set filetype=haskell even when the
file doesn't have a .hs extension.

For example:
```
au BufRead,BufNewFile * if search('^#!/usr/bin/env stack$', 'nw') | setlocal filetype=haskell | endif
```