### PR TITLE
Format visual selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,17 @@ The specific flags for Ormolu can be configured by changing the Vim variable
 let g:ormolu_options=["--unsafe"]
 ```
 
+To format a visual block range call `OrmoluBlock()` function. For example to
+bind to the key sequence <kbd>t</kbd><kbd>b</kbd> use:
+
+```vim
+xnoremap tb :<c-u>call OrmoluBlock()<CR>
+```
+
 To disable the formatting on a specific buffer use `let b:ormolu_disable=1`.
 
 If instead of formatting on save, you wish to bind formatting to a specific
-keypress add the following to your `.vimrc` or `init.vim`. For example to bind
+keypress add the following to your `.vimrc` or `init.vim`.  For example to bind
 to the key sequence <kbd>t</kbd><kbd>f</kbd> use:
 
 ```vim

--- a/ftplugin/haskell/ormolu-haskell.vim
+++ b/ftplugin/haskell/ormolu-haskell.vim
@@ -44,6 +44,72 @@ function! s:RunOrmolu()
   endif
 endfunction
 
+function! OrmoluBlock()
+    let [line_start, column_start] = getpos("'<")[1:2]
+    let [line_end, column_end] = getpos("'>")[1:2]
+    let lines = getline(line_start, line_end)
+    let length = 1 + (line_end-line_start)
+    let output = system(g:ormolu_command . " " . join(g:ormolu_options, ' '), lines)
+    let formatted = split(output, '\v\n')
+
+    if v:shell_error != 0
+      echom output
+    else
+
+      "echom length
+      "echom len(formatted)
+
+      if length > len(formatted)
+        let max = line_end - 1
+      else
+        let max = (line_start + len(formatted)) - 1
+      endif
+
+      "echom line_start
+      "echom max
+
+      " If the length of outputted code is longer than visual block append empty
+      " lines to fill
+      if len(formatted) > length
+        "echom "Longer"
+        "echom (len(formatted) - length)
+        let c = 0
+        while c < (len(formatted) - length)
+          call append(line_end, "")
+          let c = c+1
+        endwhile
+      endif
+
+      " If the length of outputted code is longer than visual block delete lines
+      if len(formatted) < length
+        "echom "Shorter"
+        let c = 0
+        "echom (length - len(formatted))
+        while c < (length - len(formatted))
+          normal! dd
+          let c = c+1
+        endwhile
+      endif
+
+      " Empty the visual block
+      let currentLine=line_start
+      while currentLine <= line_end
+        call setline(currentLine, "")
+        let currentLine = currentLine + 1
+      endwhile
+
+      " Replace with ormolu output
+      let currentLine=line_start
+      let ix=0
+      while currentLine <= max
+        "echom "Replacing"
+        call setline(currentLine, formatted[ix])
+        let currentLine = currentLine + 1
+        let ix = ix + 1
+      endwhile
+    endif
+endfunction
+
 function! RunOrmolu()
   call s:OrmoluHaskell()
 endfunction


### PR DESCRIPTION
Adds support for formatting visual selections for #3 for @denibertovic . This simply pipes the current line selection to stdin of ormolu and then tries to replace the output with stdout. Some weird edge cases where the number of input lines and output lines don't match.

Vimscript is absolutely terrible at visual buffer manipulations open to suggestions of a better way to do this :cry: 