### PR TITLE
README: fix ormoul_command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ the location of the ormolu binary. For example if you want to use
 argument.
 
 ```vim
-let g:ormolu_command=["fourmolu"]
+let g:ormolu_command="fourmolu"
 ```
 
 The specific flags for Ormolu can be configured by changing the Vim variable


### PR DESCRIPTION
Passing the `ormolu_command` override as written results in a vim error.